### PR TITLE
Set initial_RED to 1

### DIFF
--- a/Klipper_Macros/stealthburner_leds.cfg
+++ b/Klipper_Macros/stealthburner_leds.cfg
@@ -17,7 +17,7 @@
 # color_order: GRBW
 # #   Set the pixel order required by the LED hardware. Options are GRB,
 # #   RGB, GRBW, or RGBW. The default is GRB.
-# initial_RED: 0.0
+# initial_RED: 1.0
 # initial_GREEN: 0.0
 # initial_BLUE: 0.0
 # initial_WHITE: 0.0


### PR DESCRIPTION
People complain about their Neopixels not working, not knowing that they need to call the macros before anything happens.

This PR is to set `initial_RED` to 1 to have a better out-of-the-box experience and less trouble for us supporters trying to figure out if the wiring is wrong or if people just don't know about the macros.